### PR TITLE
Update @tokenizer/http from version v0.6.0 to v0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "tailwindcss-interaction-variants": "^5.0.0"
   },
   "dependencies": {
-    "@tokenizer/http": "^0.6.0",
+    "@tokenizer/http": "^0.6.2",
     "delay": "^5.0.0",
     "fast-text-encoding": "^1.0.3",
     "file-saver": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@tokenizer/http': ^0.6.0
+  '@tokenizer/http': ^0.6.2
   assert: ^2.0.0
   autoprefixer: ^10.4.7
   buffer: ^6.0.3
@@ -31,7 +31,7 @@ specifiers:
   webnative-elm: 7.0.0
 
 dependencies:
-  '@tokenizer/http': 0.6.1
+  '@tokenizer/http': 0.6.2
   delay: 5.0.0
   fast-text-encoding: 1.0.3
   file-saver: 2.0.5
@@ -189,28 +189,26 @@ packages:
       defer-to-connect: 2.0.0
     dev: true
 
-  /@tokenizer/http/0.6.1:
-    resolution: {integrity: sha512-NCyA/ZS2VUJDPhP5wIt9YUqFFMrBwUvh8nGugVfTFoEH95qD4TOVYTS5N2Nu9TA+R5kPT80wov8ZP0d4BPwDSQ==}
+  /@tokenizer/http/0.6.2:
+    resolution: {integrity: sha512-0+gTDUT9EYxbJvDYRk65Itw68gfGPUmUNz9hlAA4j/Mih7QOfyN6fVxvtTB6ytgOTo7GU1x9KRIGlrqVdjHSYw==}
     dependencies:
-      '@tokenizer/range': 0.3.3
-      debug: 4.3.1
-      node-fetch: 2.6.1
-      strtok3: 6.0.4
+      '@tokenizer/range': 0.5.1
+      debug: 4.3.4
+      node-fetch: 2.6.7
+      strtok3: 6.3.0
     transitivePeerDependencies:
+      - encoding
       - supports-color
     dev: false
 
-  /@tokenizer/range/0.3.3:
-    resolution: {integrity: sha512-kEIGyLK31/woTYkdJLAVXTcZ6d55J/Ir2y/2S9PnA4MjJPRqlZBssDwKSkEwnuLEZEhQPscKkIC1husW1UC08A==}
+  /@tokenizer/range/0.5.1:
+    resolution: {integrity: sha512-yXASo+mUC/NO954ZaVXmv+pD3wUUoq9P3lQ4MQ8JfYxmivSFXte1TbHDqqsW7seWxqiPttA+0LaZKmFP+1jYjA==}
+    engines: {node: '>=10'}
     dependencies:
       debug: 4.3.4
-      strtok3: 6.0.4
+      strtok3: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@tokenizer/token/0.1.1:
-    resolution: {integrity: sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==}
     dev: false
 
   /@tokenizer/token/0.3.0:
@@ -225,10 +223,6 @@ packages:
       '@types/node': 16.4.1
       '@types/responselike': 1.0.0
     dev: true
-
-  /@types/debug/4.1.5:
-    resolution: {integrity: sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==}
-    dev: false
 
   /@types/http-cache-semantics/4.0.0:
     resolution: {integrity: sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==}
@@ -585,18 +579,6 @@ packages:
 
   /cuint/0.2.2:
     resolution: {integrity: sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=}
-    dev: false
-
-  /debug/4.3.1:
-    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
     dev: false
 
   /debug/4.3.4:
@@ -1942,9 +1924,16 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /node-fetch/2.6.1:
-    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
     dev: false
 
   /node-releases/2.0.5:
@@ -2119,11 +2108,6 @@ packages:
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
-
-  /peek-readable/3.1.0:
-    resolution: {integrity: sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA==}
-    engines: {node: '>=8'}
-    dev: false
 
   /peek-readable/4.1.0:
     resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
@@ -2502,15 +2486,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strtok3/6.0.4:
-    resolution: {integrity: sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@tokenizer/token': 0.1.1
-      '@types/debug': 4.1.5
-      peek-readable: 3.1.0
-    dev: false
-
   /strtok3/6.3.0:
     resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
     engines: {node: '>=10'}
@@ -2640,6 +2615,10 @@ packages:
       ieee754: 1.2.1
     dev: false
 
+  /tr46/0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
   /tv4/1.3.0:
     resolution: {integrity: sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM=}
     engines: {node: '>= 0.8.0'}
@@ -2763,6 +2742,10 @@ packages:
       xhr2: 0.1.4
     dev: false
 
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
   /webnative-elm/7.0.0_webnative@0.32.0:
     resolution: {integrity: sha512-i52PkbknlbPAXPrW9ygPMhM8GK5TOHdLsGK0HmzB7qPdPbP2hzL3td574KKiWcF3esf/thuKCc6L+Qx2j2nwFw==}
     peerDependencies:
@@ -2791,6 +2774,13 @@ packages:
     transitivePeerDependencies:
       - node-fetch
       - supports-color
+    dev: false
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: false
 
   /which-boxed-primitive/1.0.2:


### PR DESCRIPTION
Update @tokenizer/http from version v0.6.0 to [v0.6.2](https://github.com/Borewit/tokenizer-http/releases/tag/v0.6.2), addressing security vulnerability in node-fetch dependency.