### PR TITLE
Fix broken elm package reference

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -42,7 +42,7 @@
       "prozacchiwawa/elm-urlbase64": "1.0.6",
       "robinheghan/murmur3": "1.0.0",
       "rtfeldman/elm-hex": "1.0.0",
-      "ryannhg/date-format": "2.3.0",
+      "ryan-haskell/date-format": "1.0.0",
       "truqu/elm-base64": "2.0.4",
       "truqu/elm-md5": "1.1.0",
       "wernerdegroot/listzipper": "4.0.0",


### PR DESCRIPTION
Ryan changed his username a while ago and it caused builds to break with this error:
```
I downloaded the source code for ryannhg/date-format 2.3.0 from:

    https://github.com/ryannhg/date-format/zipball/2.3.0/

But it looks like the hash of the archive has changed since publication:

  Expected: 70c67866fed499bec685f43f23fea279556757f2
    Actual: 86534146f5a550bb8e87b87a7484ea5732090bb5

This usually means that the package author moved the version tag, so report it
to them and see if that is the issue. Folks on Elm slack can probably help as
well.
```

This just fixes that broken reference.


Related announcement in the elm discourse:
https://discourse.elm-lang.org/t/ryannhg-packages-renamed-to-ryan-haskell/9705