### PR TITLE
Fix: spelling of environment in diffuse-facet skill

### DIFF
--- a/src/skills/diffuse-facet/SKILL.md
+++ b/src/skills/diffuse-facet/SKILL.md
@@ -136,7 +136,7 @@ queue.unshift(); // previous track
 ### Additional requirements and notes
 
 - When working with track lists, realise that there could be a huge number of tracks that you need to work with (eg. 20000 tracks). Implement a custom virtual scroll (see the winamp or blur browser elements for examples).
-- Prefer the lit-html library as the templating/rendering engine. It is available from `~/vendor/lit-html/index.js` (among some other libraries such as: `idb-keyval`, `throttle-debounce`, several `@atcute` libraries, and `kmenu-core`). Always make sure to use the `~/vendor/` prefix for libraries, you're not working in an enviroment that bundles code.
+- Prefer the lit-html library as the templating/rendering engine. It is available from `~/vendor/lit-html/index.js` (among some other libraries such as: `idb-keyval`, `throttle-debounce`, several `@atcute` libraries, and `kmenu-core`). Always make sure to use the `~/vendor/` prefix for libraries, you're not working in an environment that bundles code.
 - Prefer to fetch the tracks from the `scoped-tracks` orchestrator element.
 - Always prefer to use an orchestrator or another component instead of reimplementing logic yourself.
 - Be mindful of performance.


### PR DESCRIPTION
## Summary

Corrects a misspelling in `src/skills/diffuse-facet/SKILL.md` (`enviroment` → `environment`).

The line tells agents they are not in a bundling environment and must import from `~/vendor/`. That constraint is easy to miss if the word itself is misspelled.

Docs-only, no code changes.